### PR TITLE
Typo `aimport argparse` -> `import argparse`

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1,4 +1,4 @@
-aimport argparse
+import argparse
 import os
 import random
 import socket


### PR DESCRIPTION
It's not a big fix, but I fixed the typo in the `import` statement.